### PR TITLE
DEV: update component to be compatible with glimmer header

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -5,7 +5,6 @@
   .top-level-links {
     list-style: none;
     display: flex;
-    justify-content: center;
     align-items: center;
     gap: 1rem;
 

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -6,10 +6,5 @@
 
 .before-header-panel-outlet:has(.custom-header-links) {
   flex: 0 auto;
-  margin: 0 auto;
   overflow: hidden;
-
-  + .panel {
-    margin-left: 0;
-  }
 }

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -3,3 +3,13 @@
     display: none;
   }
 }
+
+.before-header-panel-outlet:has(.custom-header-links) {
+  flex: 0 auto;
+  margin: 0 auto;
+  overflow: hidden;
+
+  + .panel {
+    margin-left: 0;
+  }
+}

--- a/javascripts/discourse/api-initializers/header_category_dropdown.js
+++ b/javascripts/discourse/api-initializers/header_category_dropdown.js
@@ -1,22 +1,6 @@
-import { hbs } from "ember-cli-htmlbars";
 import { apiInitializer } from "discourse/lib/api";
-import RenderGlimmer from "discourse/widgets/render-glimmer";
-import { createWidget } from "discourse/widgets/widget";
+import CustomHeaderLinks from "../components/custom-header-links";
 
-export default apiInitializer("0.11.1", (api) => {
-  createWidget("custom-header-links", {
-    html() {
-      return [
-        new RenderGlimmer(
-          this,
-          "nav.custom-header-links",
-          hbs`<CustomHeaderLinks />`
-        ),
-      ];
-    },
-  });
-
-  api.decorateWidget("home-logo:after", (helper) => {
-    return helper.attach("custom-header-links");
-  });
+export default apiInitializer("1.15.0", (api) => {
+  api.renderInOutlet("before-header-panel", CustomHeaderLinks);
 });

--- a/javascripts/discourse/components/custom-header-links.hbs
+++ b/javascripts/discourse/components/custom-header-links.hbs
@@ -1,20 +1,22 @@
-{{#if this.site.mobileView}}
-  <span class="btn-custom-header-dropdown-mobile">
-    <DButton
-      @icon="caret-square-down"
-      @title="header_category_dropdown.show_header_links"
-      @action={{action this.toggleHeaderLinks}}
-    />
-  </span>
-{{/if}}
-{{#if this.showLinks}}
-  <ul class="top-level-links">
-    {{#each this.headerLinks as |item|}}
-      <CustomHeaderLink
-        @item={{item}}
-        @showHeaderLinks={{this.showLinks}}
-        @onClick={{this.toggleHeaderLinks}}
+<nav class="custom-header-links">
+  {{#if this.site.mobileView}}
+    <span class="btn-custom-header-dropdown-mobile">
+      <DButton
+        @icon="caret-square-down"
+        @title="header_category_dropdown.show_header_links"
+        @action={{action this.toggleHeaderLinks}}
       />
-    {{/each}}
-  </ul>
-{{/if}}
+    </span>
+  {{/if}}
+  {{#if this.showLinks}}
+    <ul class="top-level-links">
+      {{#each this.headerLinks as |item|}}
+        <CustomHeaderLink
+          @item={{item}}
+          @showHeaderLinks={{this.showLinks}}
+          @onClick={{this.toggleHeaderLinks}}
+        />
+      {{/each}}
+    </ul>
+  {{/if}}
+</nav>


### PR DESCRIPTION
This removes `decorateWidget` and uses a plugin outlet instead — some styles needed some updating to accommodate the new position.

Before:
![image](https://github.com/discourse/header-category-dropdown/assets/1681963/5a046b13-5ec6-440d-9a0a-24195a819d78)


After:
![image](https://github.com/discourse/header-category-dropdown/assets/1681963/d4b6dd0f-69fd-4804-b5bf-9f085816acaf)

(there's no visible change) 