### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.4.0.beta2-dev: bb176956c2b28cfda8133ad9b6926c768eada1b8
 < 3.4.0.beta1-dev: b11ee52ac1a1793245e13b6de757dd32f03a4dfa
 < 3.3.0.beta1-dev: d1e1159b21925af85990c756578ec5fbee50726e

--- a/about.json
+++ b/about.json
@@ -7,7 +7,7 @@
   },
   "modifiers": {
     "svg_icons": [
-      "caret-square-down"
+      "square-caret-down"
     ]
   }
 }

--- a/javascripts/discourse/components/custom-header-links.hbs
+++ b/javascripts/discourse/components/custom-header-links.hbs
@@ -2,7 +2,7 @@
   {{#if this.site.mobileView}}
     <span class="btn-custom-header-dropdown-mobile">
       <DButton
-        @icon="caret-square-down"
+        @icon="square-caret-down"
         @title="header_category_dropdown.show_header_links"
         @action={{action this.toggleHeaderLinks}}
       />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.